### PR TITLE
fix(runtime): stop closing s.Events in Stop; use Base.StopWatcher

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -439,13 +439,10 @@ func (s *Runtime) Stop(ctx context.Context, req *runtimev0.StopRequest) (*runtim
 		}
 	}
 
-	if s.Watcher != nil {
-		s.Watcher.Pause()
-	}
-	if s.Events != nil {
-		close(s.Events)
-		s.Events = nil
-	}
+	// Cancel the watcher and let its Start goroutine's deferred close of Events
+	// run exactly once — Stop/Destroy must not close Events itself, or it races
+	// that goroutine into a "close of closed channel" panic.
+	s.Base.StopWatcher()
 
 	return s.Runtime.StopResponse()
 }
@@ -458,13 +455,10 @@ func (s *Runtime) Destroy(ctx context.Context, req *runtimev0.DestroyRequest) (*
 	// container mode it leaked a paused `sleep infinity` container, and a
 	// Destroy without a preceding Stop leaked the whole node process tree.
 	// Shutdown stops AND removes all resources.
-	if s.Watcher != nil {
-		s.Watcher.Pause()
-	}
-	if s.Events != nil {
-		close(s.Events)
-		s.Events = nil
-	}
+	// Cancel the watcher and let its Start goroutine's deferred close of Events
+	// run exactly once — Stop/Destroy must not close Events itself, or it races
+	// that goroutine into a "close of closed channel" panic.
+	s.Base.StopWatcher()
 	if s.runner != nil {
 		_ = s.runner.Stop(ctx)
 		s.runner = nil


### PR DESCRIPTION
Same double-close-on-shutdown bug as codefly-dev/core#49 (merged): `s.Events` was closed by both `code.Watcher.Start`'s `defer close` and `Runtime.Stop`, racing into `panic: close of closed channel` and crashing the agent on teardown/Ctrl-C. Stop now calls `s.Base.StopWatcher()` (cancels the watcher; its deferred close runs once) instead of closing the channel itself.

Builds via the shared `go.work` today; the `go.mod` core bump to a version containing `services.Base.StopWatcher` lands with the next core publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)